### PR TITLE
Configure FPM Status page and dynamic pm

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -124,7 +124,7 @@ wp_themes: []
 # Meta
 #
 
-# Apache config based on precense of ultrastack
+# Apache config based on presence of ultrastack
 use_ultrastack: false
 
 # Whether a letsencrypt SSL should be generated.

--- a/templates/etc/httpd/conf.d/site.conf.j2
+++ b/templates/etc/httpd/conf.d/site.conf.j2
@@ -25,6 +25,16 @@
 
     TraceEnable Off
 
+    <Location "/fpm-status">
+        Order Allow,Deny 
+        Allow from 127.0.0.1
+        ProxyPass unix:{{ php_fpm_socket_path }}|fcgi://localhost/fpm-status
+    </Location>
+
+    <Location "/fpm-ping">
+        ProxyPass unix:{{ php_fpm_socket_path }}|fcgi://localhost/fpm-ping
+    </Location>
+
     <Directory /home/{{ system_user }}/{{ wp_system_folder }}/>
         Options FollowSymLinks
         AllowOverride All
@@ -59,6 +69,16 @@
     DirectoryIndex index.html index.php
 
     TraceEnable Off
+
+    <Location "/fpm-status">
+        Order Allow,Deny 
+        Allow from 127.0.0.1
+        ProxyPass unix:{{ php_fpm_socket_path }}|fcgi://localhost/fpm-status
+    </Location>
+
+    <Location "/fpm-ping">
+        ProxyPass unix:{{ php_fpm_socket_path }}|fcgi://localhost/fpm-ping
+    </Location>
 
     <Directory /home/{{ system_user }}/{{ wp_system_folder }}>
         Options FollowSymLinks

--- a/templates/etc/php-fpm.d/site.conf.j2
+++ b/templates/etc/php-fpm.d/site.conf.j2
@@ -22,9 +22,14 @@ php_value[session.save_handler] = files
 php_value[session.save_path] = /var/lib/php/session
 php_value[soap.wsdl_cache_dir] = /var/lib/php/wsdlcache
 
-pm = ondemand
+pm = dynamic
 pm.max_children = {{ (ansible_memtotal_mb / php_proc_mem * children_buffer) | int }}
+pm.min_spare_servers = {{ ((ansible_memtotal_mb / php_proc_mem * children_buffer) / 3) | int }}
+pm.max_spare_servers = {{ (ansible_memtotal_mb / php_proc_mem * children_buffer) | int }}
+pm.start_servers = {{ ((ansible_memtotal_mb / php_proc_mem * children_buffer) / 3) | int }}
 pm.max_requests = 200
 pm.process_idle_timeout = 10s
+pm.status_path = /fpm-status
+ping.path = /fpm-ping
 
 slowlog = {{ php_fpm_slowlog }}


### PR DESCRIPTION
Configure FPM Status and Ping pages in individual site pool settings. Additionally each Apache virtualhost has a Location block to handle the proxypass to fcgi. Switched FPM process manager from ondemand to dynamic with settings for min_spare_servers, max_spare_servers, and start_servers that is 1/3 of the max_children calculated from memory resources. 