### PR TITLE
NGX-241: skip welcome email when installing wp core

### DIFF
--- a/tasks/wordpress.yml
+++ b/tasks/wordpress.yml
@@ -77,6 +77,7 @@
     --admin_user="{{ site_user }}"
     --admin_password="{{ site_pass }}"
     --admin_email="{{ site_email }}"
+    --skip-email
   args:
     chdir: "{{ wp_system_path }}"
   become: true


### PR DESCRIPTION
- Don't send an email notification to the new admin user.