### PR TITLE
NGX-287: remove all dependencies on apache/mysql/php-fpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ releases of each, which at the time of writing are as follows:
 
 # Dependencies
 ```yaml
-- role: inmotionhosting.apache
-- role: inmotionhosting.mysql
-- role: inmotionhosting.php_fpm
 - collection: community.general
 - collection: ansible.posix
 ```

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,7 +28,4 @@ galaxy_info:
     - mysql
     - php
 
-dependencies:
-  - inmotionhosting.apache
-  - inmotionhosting.mysql
-  - inmotionhosting.php_fpm
+dependencies: []

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,7 +2,4 @@
 - name: Converge
   hosts: all
   roles:
-    - role: inmotionhosting.apache
-    - role: inmotionhosting.mysql
-    - role: inmotionhosting.php_fpm
     - role: ansible-role-wordpress

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,10 +1,3 @@
 ---
 collections:
   - name: community.general
-roles:
-  - name: inmotionhosting.apache
-    version: 1.3.1
-  - name: inmotionhosting.mysql
-    version: 1.3.3
-  - name: inmotionhosting.php_fpm
-    version: 1.3.0


### PR DESCRIPTION
- wp3-ultrastack-playbook is configured to run apache/mysql/php-fpm roles prior to the wordpress role.  Having wordpress configured with these as dependencies causes duplicate runs of them.