### PR TITLE
NGX-289: remove extra apache site configs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,21 @@
     dest: "{{ apache_config_site_path }}/{{ site_domain }}.conf"
   notify: restart apache
 
+- name: Identify extra site configs
+  ansible.builtin.find:
+    paths: "{{ apache_config_site_path }}"
+    file_type: file
+    contains: '.*site\.conf\.j2.*'
+    excludes: "{{ site_domain }}.conf"
+  register: apache_extra_sites
+
+- name: Remove extra site configs
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ apache_extra_sites.files }}"
+  notify: restart apache
+
 #
 # PHP
 #

--- a/templates/etc/httpd/conf.d/site.conf.j2
+++ b/templates/etc/httpd/conf.d/site.conf.j2
@@ -1,5 +1,6 @@
 # {{ template_destpath }}
 # {{ ansible_managed }}
+# tags: site.conf.j2
 
 {% if use_ultrastack %}
 RemoteIPHeader X-Forwarded-For


### PR DESCRIPTION
- Remove any extra site configs for a different site_domain used in a previous playbook run.