### PR TITLE
NGX-289: remove extra php-fpm pool configs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,21 @@
     - /etc/php-fpm.d/www.conf
   notify: restart php-fpm
 
+- name: Identify extra fpm pool configs
+  ansible.builtin.find:
+    paths: "{{ php_fpm_config_pool_path }}"
+    file_type: file
+    contains: '.*site\.conf\.j2.*'
+    excludes: "{{ site_domain }}.conf"
+  register: php_fpm_extra_pools
+
+- name: Remove extra site configs
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ php_fpm_extra_pools.files }}"
+  notify: restart php-fpm
+
 #
 # WordPress
 #

--- a/templates/etc/php-fpm.d/site.conf.j2
+++ b/templates/etc/php-fpm.d/site.conf.j2
@@ -1,5 +1,6 @@
 ; {{ template_destpath }}
 ; {{ ansible_managed }}
+; tags: site.conf.j2
 
 [{{ system_user }}]
 user = {{ system_user }}


### PR DESCRIPTION
- Remove extra PHP-FPM pool configs that were created for different site_domain's in previous ansible runs.