### PR TITLE
NGX-299: cast use_letsencrypt to bool

### DIFF
--- a/templates/etc/httpd/conf.d/site.conf.j2
+++ b/templates/etc/httpd/conf.d/site.conf.j2
@@ -10,7 +10,7 @@ LogFormat "%v:%p %a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" v
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
 {% endif %}
 
-{% if not use_letsencrypt %}
+{% if not use_letsencrypt|bool %}
 <VirtualHost *:{{ apache_port_http }}>
     ServerName {{ site_domain }}
     ServerAlias www.{{ site_domain }}
@@ -18,7 +18,7 @@ LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_c
     ErrorLog /var/log/{{ apache_name }}/{{ site_domain }}-error.log
     CustomLog /var/log/{{ apache_name }}/{{ site_domain }}-access.log vhost_combined
 
-{% if use_letsencrypt and not use_ultrastack %}
+{% if use_letsencrypt|bool and not use_ultrastack|bool %}
     Redirect permanent / https://{{ site_domain }}/
 {% else %}
     <Proxy "unix:{{ php_fpm_socket_path }}|fcgi://{{ system_user }}">
@@ -53,7 +53,7 @@ LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_c
 </VirtualHost>
 {% endif %}
 
-{% if use_letsencrypt %}
+{% if use_letsencrypt|bool %}
 <VirtualHost *:{{ apache_port_https }}>
     ServerName {{ site_domain }}
     ServerAlias www.{{ site_domain }}


### PR DESCRIPTION
When use_letsencrypt=false is passed an extra variable to the ansible-playbook command, it is treated as a string. If a python string is non-empty then it will always evalute to true. Instead we need to cast use_letsencrypt to a bool. This ensures the logic works as intended in several places within the role.