### PR TITLE
NGX-300: cast usage of use_letsencrypt in main.yml to bool

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -124,7 +124,7 @@
     wp_protocol: >-
       {{ "https://"
       if use_letsencrypt is defined
-      and use_letsencrypt
+      and use_letsencrypt|bool
       else "http://" }}
 
 - name: Ensure WordPress siteurl and homeurl are correct
@@ -139,7 +139,7 @@
     wp_protocol: >-
       {{ "https://"
       if use_letsencrypt is defined
-      and use_letsencrypt
+      and use_letsencrypt|bool
       else "http://" }}
   with_items:
     - siteurl
@@ -160,12 +160,12 @@
 
     "{{ 'http://'
     if use_letsencrypt is defined
-    and use_letsencrypt
+    and use_letsencrypt|bool
     else 'https://' }}"
 
     "{{ 'https://'
     if use_letsencrypt is defined
-    and use_letsencrypt
+    and use_letsencrypt|bool
     else 'http://' }}"
   args:
     chdir: "{{ wp_system_path }}"

--- a/templates/etc/httpd/conf.d/site.conf.j2
+++ b/templates/etc/httpd/conf.d/site.conf.j2
@@ -2,7 +2,7 @@
 # {{ ansible_managed }}
 # tags: site.conf.j2
 
-{% if use_ultrastack %}
+{% if use_ultrastack|bool %}
 RemoteIPHeader X-Forwarded-For
 RemoteIPInternalProxy 127.0.0.0/8 ::1 {{ ansible_default_ipv4.address }}
 LogFormat "%v:%p %a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined


### PR DESCRIPTION
- Logic to set the appropriate protocol (http/https) in the siteurl was not working properly.  If use_letsencrypt=false is passed as an extra variable, it is treated as a string and evaluates to true unless casted to a bool.