### PR TITLE
NGX-344: fix fpm pool logging; port addtl php settings; linting

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -144,5 +144,7 @@ php_proc_mem: 64
 # PHP memory allocation = server memory (MB) / php_proc_mem (MB) * children_buffer
 children_buffer: 0.75
 
-php_allow_url_fopen: on
-php_allow_url_include: off
+php_allow_url_fopen: 'on'
+php_allow_url_include: 'off'
+php_catch_workers_output: 'yes'
+php_request_slowlog_timeout: 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,12 @@
     path: "/home/{{ system_user }}"
     mode: 0711
 
+- name: Create the system user ~/logs directory
+  file:
+    path: "/home/{{ system_user }}/logs"
+    mode: 0755
+    state: directory
+
 #
 # Apache
 #
@@ -126,7 +132,7 @@
       wp_protocol: >-
         {{ "https://"
         if use_letsencrypt is defined
-        and use_letsencrypt|bool
+        and use_letsencrypt | bool
         else "http://" }}
 
   - name: Ensure WordPress siteurl and homeurl are correct
@@ -141,7 +147,7 @@
       wp_protocol: >-
         {{ "https://"
         if use_letsencrypt is defined
-        and use_letsencrypt|bool
+        and use_letsencrypt | bool
         else "http://" }}
     with_items:
       - siteurl
@@ -162,12 +168,12 @@
 
       "{{ 'http://'
       if use_letsencrypt is defined
-      and use_letsencrypt|bool
+      and use_letsencrypt | bool
       else 'https://' }}"
 
       "{{ 'https://'
       if use_letsencrypt is defined
-      and use_letsencrypt|bool
+      and use_letsencrypt | bool
       else 'http://' }}"
     args:
       chdir: "{{ wp_system_path }}"

--- a/templates/etc/httpd/conf.d/site.conf.j2
+++ b/templates/etc/httpd/conf.d/site.conf.j2
@@ -2,7 +2,7 @@
 # {{ ansible_managed }}
 # tags: site.conf.j2
 
-{% if use_ultrastack|bool %}
+{% if use_ultrastack | bool %}
 RemoteIPHeader X-Forwarded-For
 RemoteIPInternalProxy 127.0.0.0/8 ::1 {{ ansible_default_ipv4.address }}
 LogFormat "%v:%p %a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
@@ -10,7 +10,7 @@ LogFormat "%v:%p %a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" v
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
 {% endif %}
 
-{% if not use_letsencrypt|bool %}
+{% if not use_letsencrypt | bool %}
 <VirtualHost *:{{ apache_port_http }}>
     ServerName {{ site_domain }}
     ServerAlias www.{{ site_domain }}
@@ -18,7 +18,7 @@ LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_c
     ErrorLog /var/log/{{ apache_name }}/{{ site_domain }}-error.log
     CustomLog /var/log/{{ apache_name }}/{{ site_domain }}-access.log vhost_combined
 
-{% if use_letsencrypt|bool and not use_ultrastack|bool %}
+{% if use_letsencrypt | bool and not use_ultrastack | bool %}
     Redirect permanent / https://{{ site_domain }}/
 {% else %}
     <Proxy "unix:{{ php_fpm_socket_path }}|fcgi://{{ system_user }}">

--- a/templates/etc/php-fpm.d/site.conf.j2
+++ b/templates/etc/php-fpm.d/site.conf.j2
@@ -2,9 +2,10 @@
 ; {{ ansible_managed }}
 ; tags: site.conf.j2
 
-[{{ system_user }}]
+[{{ site_domain | replace(".", "_")}}]
 user = {{ system_user }}
 group = {{ system_user }}
+chdir = /home/{{ system_user }}
 
 listen = {{ php_fpm_socket_path }}
 listen.allowed_clients = 127.0.0.1
@@ -12,9 +13,13 @@ listen.owner = {{ apache_user }}
 listen.group = {{ apache_group }}
 listen.mode = 0660
 
-php_admin_flag[allow_url_fopen] = {{ php_allow_url_fopen }}
-php_admin_flag[allow_url_include] = {{ php_allow_url_include }}
+catch_workers_output = {{ 'yes' if php_catch_workers_output | bool else 'no' }}
+
+php_admin_flag[allow_url_fopen] = {{ 'on' if php_allow_url_fopen | bool else 'off' }}
+php_admin_flag[allow_url_include] = {{ 'on' if php_allow_url_include | bool else 'off' }}
 php_admin_flag[log_errors] = on
+
+php_admin_value[doc_root] = "{{ wp_system_path }}"
 
 php_admin_value[disable_functions] = exec,passthru,shell_exec,system
 php_admin_value[error_log] = {{ php_fpm_site_errorlog }}
@@ -32,6 +37,9 @@ pm.start_servers = {{ ((ansible_memtotal_mb / php_proc_mem * children_buffer | f
 pm.max_requests = 200
 pm.process_idle_timeout = 10s
 pm.status_path = /status
-ping.path = /fpm-ping
+ping.path = /ping
 
+security.limit_extensions = .phtml .php .php3 .php4 .php5 .php6 .php7 .php8
+
+request_slowlog_timeout = {{ php_request_slowlog_timeout }}
 slowlog = {{ php_fpm_slowlog }}


### PR DESCRIPTION
- Resolve error logging failures; Configure error logging to path which `system_user` can write to.
- Port additional settings from existing Ultrastack configuration to fpm pool configuration: chdir, catch_workers_output, doc_root, pool name scheme, security.limit_extensions.
- Add request_slowlog_timeout variable for the ability to log slow fpm executions. A value of '0' means 'Off'. Available units: s(econds)(default), m(inutes), h(ours), or d(ays). Default value: 0.
- Various ansible linting fixes