### PR TITLE
NGX-368: Use <IfModule> around RemoteIP* directives

### DIFF
--- a/templates/etc/httpd/conf.d/site.conf.j2
+++ b/templates/etc/httpd/conf.d/site.conf.j2
@@ -3,11 +3,11 @@
 # tags: site.conf.j2
 
 {% if use_ultrastack | bool %}
-RemoteIPHeader X-Forwarded-For
-RemoteIPInternalProxy 127.0.0.0/8 ::1 {{ ansible_default_ipv4.address }}
-LogFormat "%v:%p %a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
-{% else %}
-LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+<IfModule remoteip_module>
+    RemoteIPHeader X-Forwarded-For
+    RemoteIPInternalProxy 127.0.0.0/8 ::1 {{ ansible_default_ipv4.address }}
+    LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+</IfModule>
 {% endif %}
 
 {% if not use_letsencrypt | bool %}
@@ -16,7 +16,7 @@ LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_c
     ServerAlias www.{{ site_domain }}
 
     ErrorLog /var/log/{{ apache_name }}/{{ site_domain }}-error.log
-    CustomLog /var/log/{{ apache_name }}/{{ site_domain }}-access.log vhost_combined
+    CustomLog /var/log/{{ apache_name }}/{{ site_domain }}-access.log combined
 
 {% if use_letsencrypt | bool and not use_ultrastack | bool %}
     Redirect permanent / https://{{ site_domain }}/
@@ -59,7 +59,7 @@ LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" vhost_c
     ServerAlias www.{{ site_domain }}
 
     ErrorLog /var/log/{{ apache_name }}/ssl-{{ site_domain }}-error.log
-    CustomLog /var/log/{{ apache_name }}/ssl-{{ site_domain }}-access.log vhost_combined
+    CustomLog /var/log/{{ apache_name }}/ssl-{{ site_domain }}-access.log combined
 
     SSLEngine On
     SSLCertificateFile /etc/letsencrypt/live/{{ site_domain }}/cert.pem


### PR DESCRIPTION
- Wrapping RemoteIP* directives in an <IfModule> block prevents Apache from failing to start if the Remote IP module is not loaded.