### PR TITLE
NGX-380: Always trigger apache/php-fpm restart handlers

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,8 @@
   notify: restart apache
 
 - name: Reload apache
+  debug:
+    msg: "trigger apache restart"
   changed_when: true
   notify: restart apache
 
@@ -101,6 +103,8 @@
   notify: restart php-fpm
 
 - name: Reload php-fpm
+  debug:
+    msg: "trigger php-fpm restart"
   changed_when: true
   notify: restart php-fpm
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,6 +59,10 @@
   with_items: "{{ apache_extra_sites.files }}"
   notify: restart apache
 
+- name: Reload apache
+  changed_when: true
+  notify: restart apache
+
 #
 # PHP
 #
@@ -94,6 +98,10 @@
     path: "{{ item.path }}"
     state: absent
   with_items: "{{ php_fpm_extra_pools.files }}"
+  notify: restart php-fpm
+
+- name: Reload php-fpm
+  changed_when: true
   notify: restart php-fpm
 
 #


### PR DESCRIPTION
- Certain circumstances cause the playbook to apply changes without restarting the service.  Subsequent runs do not apply any changes, so the service is again not restarted.  This can cause service to be stuck in running state with outdated configs which playbook can not correct.  For this reason, we notify the apache, php-fpm, and nginx restart handlers on every run.