### PR TITLE
NGX-725: update php fpm pool worker counts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -140,7 +140,7 @@ install_wordpress: true
 #
 
 # Expected memory usage per PHP pool in MB
-php_proc_mem: 64
+php_proc_mem: 192
 # PHP memory allocation = server memory (MB) / php_proc_mem (MB) * children_buffer
 children_buffer: 0.75
 

--- a/templates/etc/php-fpm.d/site.conf.j2
+++ b/templates/etc/php-fpm.d/site.conf.j2
@@ -30,10 +30,10 @@ php_value[session.save_path] = /var/lib/php/session
 php_value[soap.wsdl_cache_dir] = /var/lib/php/wsdlcache
 
 pm = dynamic
-pm.max_children = {{ (ansible_memtotal_mb / php_proc_mem * children_buffer | float) | int }}
-pm.min_spare_servers = {{ ((ansible_memtotal_mb / php_proc_mem * children_buffer | float) / 3) | int }}
-pm.max_spare_servers = {{ (ansible_memtotal_mb / php_proc_mem * children_buffer | float) | int }}
-pm.start_servers = {{ ((ansible_memtotal_mb / php_proc_mem * children_buffer | float) / 3) | int }}
+pm.start_servers = {{ ((ansible_memtotal_mb / php_proc_mem | float * children_buffer | float ) / 3) | round(0, "ceil") | int }}
+pm.min_spare_servers = {{ ((ansible_memtotal_mb / php_proc_mem | float  * children_buffer | float ) / 3) | round(0, "ceil") | int }}
+pm.max_spare_servers = {{ ((ansible_memtotal_mb / php_proc_mem | float  * children_buffer | float + ansible_memtotal_mb / php_proc_mem | float  * children_buffer | float / 3) / 2) | round(0, "ceil") | int }}
+pm.max_children = {{ (ansible_memtotal_mb / php_proc_mem | float * children_buffer | float ) | round(0, "ceil") | int }}
 pm.max_requests = 200
 pm.process_idle_timeout = 10s
 pm.status_path = /status


### PR DESCRIPTION
- The number of workers is being scaled more conservatively with this change.  Instead of expecting an fpm work to use 64 MB, we now allocate 192 MB.  This is based off observations from real time data.  It also takes into account that the default memory_limit is 512 MB for php in /etc/php.ini