### PR TITLE
NGX-733: do not remove site configs that match given patterns

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -148,3 +148,7 @@ php_allow_url_fopen: 'on'
 php_allow_url_include: 'off'
 php_catch_workers_output: 'yes'
 php_request_slowlog_timeout: 0
+
+# site config conf files matching these patterns will not be removed from /etc/nginx/conf.d/
+preserve_site_config_patterns:
+  - "{{ site_domain }}.conf"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,7 +49,7 @@
     paths: "{{ apache_config_site_path }}"
     file_type: file
     contains: '.*site\.conf\.j2.*'
-    excludes: "{{ site_domain }}.conf"
+    excludes: "{{ preserve_site_config_patterns }}"
   register: apache_extra_sites
 
 - name: Remove extra site configs


### PR DESCRIPTION
- Changing the site's url creates new nginx and apache config files for the new domain.  We've been removing everything except the newest one.  This new feature allows us the user to exclude removal of any site configs that match the provided patterns.  This way we can persist the configs for the server hostname itself.