### PR TITLE
NGX-730: No --skip-columns=guid

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -11,3 +11,5 @@
 
   roles:
     - role: ansible-role-wordpress
+      vars:
+        use_letsencrypt: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -236,7 +236,7 @@
 
     - name: Replace all site urls in database if changed
       ansible.builtin.command: >-
-        wp search-replace "{{ siteurl.stdout }}" "{{ wp_protocol }}{{ site_domain }}" --skip-columns=guid
+        wp search-replace "{{ siteurl.stdout }}" "{{ wp_protocol }}{{ site_domain }}"
       args:
         chdir: "{{ wp_system_path }}"
       become: true


### PR DESCRIPTION
Guid's are usually the URL, and if changing domain names, you want to switch it. Only preserve it if you are staying on the same domain, rss readers use it for ensuring the feed is correct, among other things.