### PR TITLE
NGX-757: Redis unixsocket support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -28,9 +28,11 @@ galaxy_info:
     - apache
     - mysql
     - php
+    - redis
 
 dependencies:
   - role: inmotionhosting.apache
   - role: inmotionhosting.mysql
   - role: inmotionhosting.php_fpm
   - role: inmotionhosting.nginx_proxy
+  - role: inmotionhosting.redis

--- a/requirements.yml
+++ b/requirements.yml
@@ -7,9 +7,9 @@ roles:
   - name: inmotionhosting.php_fpm
     version: 2.1.0
   - name: inmotionhosting.nginx_proxy
-    version: 2.1.0
+    version: 2.4.2
   - name: inmotionhosting.redis
-    version: 2.1.0
+    version: 2.2.0
 collections:
   - name: community.general
   - name: community.mysql

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   ansible.builtin.user:
     name: "{{ system_user }}"
     group: "{{ system_user }}"
-    groups: "{{ system_user }},nginx,nobody"
+    groups: "{{ system_user }},nginx,nobody,redis"
 
 - name: Ensure install directory exists
   ansible.builtin.file:
@@ -187,36 +187,6 @@
     state: absent
   with_items: "{{ nginx_extra_sites.files }}"
   notify: Restart nginx
-
-#
-# Redis
-#
-
-# Redis will be disabled if the host's total memory is <= 1GB
-- name: Check Memory for Redis inclusion
-  ansible.builtin.set_fact:
-    use_redis: false
-  when:
-    - use_redis is defined
-    - use_redis
-    - ansible_memtotal_mb <= 1024
-
-- name: Include Redis role
-  ansible.builtin.include_role:
-    name: inmotionhosting.redis
-    public: true
-  when:
-    - use_redis is defined
-    - use_redis
-
-- name: Add redis group to system_user ({{ system_user }})
-  ansible.builtin.user:
-    name: "{{ system_user }}"
-    groups: redis
-    append: true
-  when:
-    - use_redis is defined
-    - use_redis
 
 #
 # WordPress

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -209,6 +209,15 @@
     - use_redis is defined
     - use_redis
 
+- name: Add redis group to system_user ({{ system_user }})
+  ansible.builtin.user:
+    name: "{{ system_user }}"
+    groups: redis
+    append: true
+  when:
+    - use_redis is defined
+    - use_redis
+
 #
 # WordPress
 #


### PR DESCRIPTION
This adds the redis group to system_user allowing WordPress plugins to connect to the redis unixsocket.