### PR TITLE
NGX-762: flush object cache after wp search-replace

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -116,6 +116,20 @@ wp_w3tc_settings:
     type: string
     value: file
 
+ultrastack_w3tc_settings:
+  - setting: dbcache.engine
+    type: string
+    value: redis
+  - setting: dbcache.redis.servers
+    type: array
+    value: "127.0.0.1:6379"
+  - setting: objectcache.engine
+    type: string
+    value: redis
+  - setting: objectcache.redis.servers
+    type: array
+    value: "127.0.0.1:6379"
+
 # WordPress theme(s) to install and activate
 wp_themes: []
 
@@ -145,6 +159,7 @@ install_wordpress: true
 
 # Expected memory usage per PHP pool in MB
 php_proc_mem: 96
+
 # PHP memory allocation = server memory (MB) / php_proc_mem (MB) * children_buffer
 children_buffer: 0.75
 
@@ -152,20 +167,6 @@ php_allow_url_fopen: 'on'
 php_allow_url_include: 'off'
 php_catch_workers_output: 'yes'
 php_request_slowlog_timeout: 0
-
-ultrastack_w3tc_settings:
-  - setting: dbcache.engine
-    type: string
-    value: redis
-  - setting: dbcache.redis.servers
-    type: array
-    value: "127.0.0.1:6379"
-  - setting: objectcache.engine
-    type: string
-    value: redis
-  - setting: objectcache.redis.servers
-    type: array
-    value: "127.0.0.1:6379"
 
 #
 # Nginx Rate Limiting
@@ -196,3 +197,15 @@ nginx_cache_honor_cookies: true
 nginx_cache_honor_expires: false
 nginx_cache_time_default: 0
 nginx_proxy_cache_enable: false
+
+#
+# SELinux
+#
+
+selinux_enabled: "{{ ansible_selinux.status }}"
+selinux_booleans:
+  - httpd_setrlimit
+  - httpd_execmem
+  - httpd_can_network_connect
+  - httpd_can_network_connect_db
+  - httpd_read_user_content

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -238,7 +238,7 @@
       become: true
       become_user: "{{ system_user }}"
       changed_when: false
-      when: "'flush' in search_replace.stdout"
+      when: "'skipped' not in search_replace"
 
     - name: Ensure WordPress siteurl and homeurl are correct
       ansible.builtin.command: >-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -228,6 +228,17 @@
           if use_letsencrypt is defined
           and use_letsencrypt | bool
           else "http://" }}
+      register: search_replace
+
+    - name: Flush WordPress persistent object cache
+      ansible.builtin.command: >-
+        wp cache flush
+      args:
+        chdir: "{{ wp_system_path }}"
+      become: true
+      become_user: "{{ system_user }}"
+      changed_when: false
+      when: "'flush' in search_replace.stdout"
 
     - name: Ensure WordPress siteurl and homeurl are correct
       ansible.builtin.command: >-
@@ -269,3 +280,11 @@
       when: nginx_helper_cache_path.stdout != nginx_cache_path
       vars:
         nginx_cache_path: "{{ nginx_cache_dir }}/{{ nginx_cache_name }}"
+
+#
+# SELinux
+#
+
+- name: Enable and configure SELinux
+  ansible.builtin.include_tasks: selinux.yml
+  when: ansible_selinux.status == "enabled"

--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -40,9 +40,9 @@ server {
         proxy_cache_bypass $cache_bypass;
 {% endif %}
 {% if use_letsencrypt is defined and use_letsencrypt|bool %}
-        proxy_pass https://http_backend;
+        proxy_pass https://apache;
 {% else %}
-        proxy_pass http://http_backend;
+        proxy_pass http://apache;
 {% endif %}
         proxy_http_version 1.1;
         proxy_set_header Connection "";
@@ -71,9 +71,9 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;        
 
 {% if use_letsencrypt is defined and use_letsencrypt|bool %}
-        proxy_pass https://http_backend;
+        proxy_pass https://apache;
 {% else %}
-        proxy_pass http://http_backend;
+        proxy_pass http://apache;
 {% endif %}
         proxy_http_version 1.1;
         proxy_set_header Connection "";
@@ -90,9 +90,9 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;        
 {% if use_letsencrypt is defined and use_letsencrypt|bool %}
-        proxy_pass https://http_backend;
+        proxy_pass https://apache;
 {% else %}
-        proxy_pass http://http_backend;
+        proxy_pass http://apache;
 {% endif %}
         proxy_http_version 1.1;
         proxy_set_header Connection "";

--- a/templates/etc/nginx/conf.d/upstream.conf.j2
+++ b/templates/etc/nginx/conf.d/upstream.conf.j2
@@ -2,7 +2,7 @@
 # {{ ansible_managed }}
 
 
-upstream http_backend {
+upstream apache {
 {% if use_letsencrypt is defined and use_letsencrypt|bool %}
     server 127.0.0.1:8443;
 {%- else %}


### PR DESCRIPTION
Following execution of wp search-replace, wp-cli prompts the user to flush cache via 'wp cache flush'.  Failure to do so will cause subsequent wp-cli command to result in Error such as setting the home, or siteurl wp_option options.

Also restored selinux functionality.  This had previously been removed in https://github.com/inmotionhosting/ansible-role-wordpress/commit/db90bd55f238b50dc1d108feea4f87c01d9590e0.

The name of the upstream server in /etc/nginx/conf.d/upstream.conf was changed from http_backend to apache.