### PR TITLE
NGX-733: Preserve hostname config

### DIFF
--- a/templates/etc/httpd/conf.d/site.conf.j2
+++ b/templates/etc/httpd/conf.d/site.conf.j2
@@ -34,8 +34,13 @@
     ProxyAddHeaders off
     ProxyPreserveHost off
 
-    ProxyPass / https://{{ site_domain }} ttl=1 disablereuse=On
-    ProxyPassReverse / https://{{ site_domain }}
+    ProxyPass / {% if not use_letsencrypt | bool %}http{% else %}https{% endif %}://{{ site_domain }}/ ttl=1 disablereuse=On
+    ProxyPassReverse / {% if not use_letsencrypt | bool %}http{% else %}https{% endif %}://{{ site_domain }}/
+
+    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Methods "GET,POST,PUT,DELETE,OPTIONS"
+    Header set Access-Control-Allow-Headers "Content-Type,Authorization,X-Requested-With,X-BGC-Auth"
+    Header set Access-Control-Allow-Credentials "true"
 </VirtualHost>
 {% endif %}
 

--- a/templates/etc/httpd/conf.d/site.conf.j2
+++ b/templates/etc/httpd/conf.d/site.conf.j2
@@ -23,34 +23,19 @@
     SSLCertificateKeyFile /etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem
     SSLCertificateChainFile /etc/letsencrypt/live/{{ ansible_fqdn }}/chain.pem
 
-    <Proxy "unix:{{ php_fpm_socket_path }}|fcgi://{{ system_user }}">
-        ProxySet disablereuse=off
-    </Proxy>
+    SSLProxyEngine on
+    SSLProxyCheckPeerCN off
+    SSLProxyCheckPeerExpire off
+    SSLProxyCheckPeerName off
+    SSLProxyVerify none 
+    SSLSessionTickets on
 
-    <FilesMatch \.php$>
-        SetHandler proxy:fcgi://{{ system_user }}
-    </FilesMatch>
+    ProxyRequests off
+    ProxyAddHeaders off
+    ProxyPreserveHost off
 
-    DocumentRoot {{ wp_system_path }}
-    DirectoryIndex index.html index.php
-
-    TraceEnable Off
-
-    <Location "/status">
-        Order Allow,Deny
-        Allow from 127.0.0.1
-        ProxyPass unix:{{ php_fpm_socket_path }}|fcgi://localhost/status
-    </Location>
-
-    <Location "/fpm-ping">
-        ProxyPass unix:{{ php_fpm_socket_path }}|fcgi://localhost/fpm-ping
-    </Location>
-
-    <Directory {{ wp_system_path }}>
-        Options FollowSymLinks
-        AllowOverride All
-        Require all granted
-    </Directory>
+    ProxyPass / https://{{ site_domain }} ttl=1 disablereuse=On
+    ProxyPassReverse / https://{{ site_domain }}
 </VirtualHost>
 {% endif %}
 

--- a/templates/etc/httpd/conf.d/site.conf.j2
+++ b/templates/etc/httpd/conf.d/site.conf.j2
@@ -10,6 +10,50 @@
 </IfModule>
 {% endif %}
 
+{% if site_domain != ansible_fqdn %}
+<VirtualHost *:{{ apache_port_https }}>
+    ServerName {{ ansible_fqdn }}
+    ServerAlias www.{{ ansible_fqdn }}
+
+    ErrorLog /var/log/{{ apache_name }}/ssl-{{ ansible_fqdn }}-error.log
+    CustomLog /var/log/{{ apache_name }}/ssl-{{ ansible_fqdn }}-access.log combined
+
+    SSLEngine On
+    SSLCertificateFile /etc/letsencrypt/live/{{ ansible_fqdn }}/cert.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem
+    SSLCertificateChainFile /etc/letsencrypt/live/{{ ansible_fqdn }}/chain.pem
+
+    <Proxy "unix:{{ php_fpm_socket_path }}|fcgi://{{ system_user }}">
+        ProxySet disablereuse=off
+    </Proxy>
+
+    <FilesMatch \.php$>
+        SetHandler proxy:fcgi://{{ system_user }}
+    </FilesMatch>
+
+    DocumentRoot {{ wp_system_path }}
+    DirectoryIndex index.html index.php
+
+    TraceEnable Off
+
+    <Location "/status">
+        Order Allow,Deny
+        Allow from 127.0.0.1
+        ProxyPass unix:{{ php_fpm_socket_path }}|fcgi://localhost/status
+    </Location>
+
+    <Location "/fpm-ping">
+        ProxyPass unix:{{ php_fpm_socket_path }}|fcgi://localhost/fpm-ping
+    </Location>
+
+    <Directory {{ wp_system_path }}>
+        Options FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>
+{% endif %}
+
 {% if not use_letsencrypt | bool %}
 <VirtualHost *:{{ apache_port_http }}>
     ServerName {{ site_domain }}

--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -3,6 +3,41 @@
 # tags: site.conf.j2
 
 
+{% if site_domain != ansible_fqdn %}
+server {
+    listen 80;
+    listen 443 ssl http2;
+
+    ssl_certificate     /etc/letsencrypt/live/{{ ansible_fqdn }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem;
+
+    server_name {{ ansible_fqdn }};
+
+    root {{ wp_system_path }};
+
+    if ($scheme != "https") {
+        return 301 https://$host$request_uri;
+    }
+
+    location / {
+        add_header X-Proxy-Cache $upstream_cache_status;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;        
+
+        proxy_no_cache 1;
+        proxy_cache_bypass 1;
+
+        proxy_pass https://apache_ssl;
+
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+    }
+}
+{% endif %}
+
 server {
     listen 80;
 {% if use_letsencrypt is defined and use_letsencrypt|bool %}
@@ -40,7 +75,7 @@ server {
         proxy_cache_bypass $cache_bypass;
 {% endif %}
 {% if use_letsencrypt is defined and use_letsencrypt|bool %}
-        proxy_pass https://apache;
+        proxy_pass https://apache_ssl;
 {% else %}
         proxy_pass http://apache;
 {% endif %}
@@ -71,7 +106,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;        
 
 {% if use_letsencrypt is defined and use_letsencrypt|bool %}
-        proxy_pass https://apache;
+        proxy_pass https://apache_ssl;
 {% else %}
         proxy_pass http://apache;
 {% endif %}
@@ -90,7 +125,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;        
 {% if use_letsencrypt is defined and use_letsencrypt|bool %}
-        proxy_pass https://apache;
+        proxy_pass https://apache_ssl;
 {% else %}
         proxy_pass http://apache;
 {% endif %}

--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -25,7 +25,9 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;        
+        proxy_set_header X-Forwarded-Host {{ site_domain }};
+        proxy_set_header X-Forwarded-Server {{ site_domain }};
+
 
         proxy_no_cache 1;
         proxy_cache_bypass 1;

--- a/templates/etc/nginx/conf.d/upstream.conf.j2
+++ b/templates/etc/nginx/conf.d/upstream.conf.j2
@@ -3,10 +3,11 @@
 
 
 upstream apache {
-{% if use_letsencrypt is defined and use_letsencrypt|bool %}
-    server 127.0.0.1:8443;
-{%- else %}
     server 127.0.0.1:8080;
-{%- endif %}    
+    keepalive 2;
+}
+
+upstream apache_ssl {
+    server 127.0.0.1:8443;
     keepalive 2;
 }


### PR DESCRIPTION
When a user changes their Site url to something other than the VPS hostname we provide them with by default, the playbook will add additional configuration to NGiNX and Apache, so that requests to the VPS hostname still properly load the WordPress site.