### PR TITLE
NGX-761: Check service configuration syntax

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,7 @@
   ansible.builtin.service:
     name: "{{ apache_daemon }}"
     state: restarted
+  when: apache_syntax.rc == 0
 
 - name: Restart mysql
   ansible.builtin.service:
@@ -13,8 +14,10 @@
   ansible.builtin.service:
     name: "{{ php_fpm_daemon }}"
     state: restarted
+  when: phpfpm_syntax.rc == 0
 
 - name: Restart nginx
   ansible.builtin.service:
     name: nginx
     state: restarted
+  when: nginx_syntax.rc == 0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,15 +1,24 @@
 ---
 roles:
   - name: inmotionhosting.apache
-    version: 2.1.0
+    src: git+ssh://git@github.com/inmotionhosting/ansible-role-apache.git
+    version: "2.1.0"
+
   - name: inmotionhosting.mysql
-    version: 2.1.0
-  - name: inmotionhosting.php_fpm
-    version: 2.3.0
+    src: git+ssh://git@github.com/inmotionhosting/ansible-role-mysql.git
+    version: "2.1.0"
+
   - name: inmotionhosting.nginx_proxy
-    version: 2.5.1
+    src: git+ssh://git@github.com/inmotionhosting/ansible-role-nginx_proxy.git
+    version: "2.5.1"
+
+  - name: inmotionhosting.php_fpm
+    src: git+ssh://git@github.com/inmotionhosting/ansible-role-php_fpm.git
+    version: "2.3.0"
+
   - name: inmotionhosting.redis
-    version: 2.2.1
+    src: git+ssh://git@github.com/inmotionhosting/ansible-role-redis.git
+    version: "2.2.1"
 collections:
   - name: community.general
   - name: community.mysql

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,11 +5,11 @@ roles:
   - name: inmotionhosting.mysql
     version: 2.1.0
   - name: inmotionhosting.php_fpm
-    version: 2.1.0
+    version: 2.3.0
   - name: inmotionhosting.nginx_proxy
-    version: 2.4.2
+    version: 2.5.1
   - name: inmotionhosting.redis
-    version: 2.2.0
+    version: 2.2.1
 collections:
   - name: community.general
   - name: community.mysql

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,23 +1,23 @@
 ---
 roles:
   - name: inmotionhosting.apache
-    src: git+ssh://git@github.com/inmotionhosting/ansible-role-apache.git
+    src: https://github.com/inmotionhosting/ansible-role-apache
     version: "2.1.0"
 
   - name: inmotionhosting.mysql
-    src: git+ssh://git@github.com/inmotionhosting/ansible-role-mysql.git
+    src: https://github.com/inmotionhosting/ansible-role-mysql
     version: "2.1.0"
 
   - name: inmotionhosting.nginx_proxy
-    src: git+ssh://git@github.com/inmotionhosting/ansible-role-nginx_proxy.git
+    src: https://github.com/inmotionhosting/ansible-role-nginx_proxy
     version: "2.5.1"
 
   - name: inmotionhosting.php_fpm
-    src: git+ssh://git@github.com/inmotionhosting/ansible-role-php_fpm.git
+    src: https://github.com/inmotionhosting/ansible-role-php_fpm
     version: "2.3.0"
 
   - name: inmotionhosting.redis
-    src: git+ssh://git@github.com/inmotionhosting/ansible-role-redis.git
+    src: https://github.com/inmotionhosting/ansible-role-redis
     version: "2.2.1"
 collections:
   - name: community.general

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,12 @@
   with_items: "{{ apache_extra_sites.files }}"
   notify: Restart apache
 
+- name: Check syntax for "{{ apache_daemon }}"
+  ansible.builtin.command: "{{ apache_daemon }} -t"
+  register: apache_syntax
+  changed_when: false
+  ignore_errors: true
+
 #
 # PHP
 #
@@ -132,6 +138,12 @@
     mode: "0644"
   when: not php_ini_result.stat.exists
 
+- name: Check syntax for "{{ php_fpm_daemon }}"
+  ansible.builtin.command: "{{ php_fpm_daemon }} -t"
+  register: phpfpm_syntax
+  changed_when: false
+  ignore_errors: true
+
 #
 # NGINX
 #
@@ -187,6 +199,13 @@
     state: absent
   with_items: "{{ nginx_extra_sites.files }}"
   notify: Restart nginx
+
+- name: Check syntax for "{{ nginx_daemon }}""
+  ansible.builtin.command: "{{ nginx_daemon}} -t"
+  register: nginx_syntax
+  changed_when: false
+  ignore_errors: true
+  tags: profile
 
 #
 # WordPress

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -139,7 +139,7 @@
   when: not php_ini_result.stat.exists
 
 - name: Check syntax for "{{ php_fpm_daemon }}"
-  ansible.builtin.command: "{{ php_fpm_daemon }} -t"
+  ansible.builtin.command: "{{ php_fpm_binary }} -t"
   register: phpfpm_syntax
   changed_when: false
   ignore_errors: true


### PR DESCRIPTION
Add additional output to playbook execution.  Failed syntax checks will result in the error being logged to playbook output.  This is useful for debugging and troubleshooting.  We also have the ability to skip execution of handlers if syntax is invalid.