### PR TITLE
NGX-789: /wp-json* Bypasses NGiNX cache; Install collections from GitHub

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,9 +182,9 @@ nginx_ratelimit_paths: ".*login\\.php|xmlrpc\\.php|wp-cron\\.php"
 #
 # Nginx Cache Configs
 #
-nginx_cache_bypass_paths: >-
-  "^(_logged_in_|items_in_cart|jsid|.*/wp-admin|.*/administrator|/admin|
-  /user|/opcache\\.php|.*/phpinfo\\.php|/basket.*|/cart.*|/my-account.*|/checkout.*|/addons.*)"
+nginx_cache_bypass_paths: "^(_logged_in_|items_in_cart|jsid|.*/wp-admin|.*/administrator|/admin|\
+  /user|/opcache\\.php|.*/phpinfo\\.php|/basket.*|/cart.*|/my-account.*|/checkout.*|/addons.*|\
+  /wp-json.*)"
 nginx_cache_purge_enable: false
 
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@
 ansible-lint
 ansible
 molecule-plugins[docker]
-molecule>=5,<6
+molecule
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # requirements.txt
 
 ansible-lint
-ansible>=6,<7
+ansible
 molecule-plugins[docker]
 molecule>=5,<6
 pre-commit

--- a/requirements.yml
+++ b/requirements.yml
@@ -20,6 +20,6 @@ roles:
     src: https://github.com/inmotionhosting/ansible-role-redis
     version: "2.2.1"
 collections:
-  - name: community.general
-  - name: community.mysql
-  - name: ansible.posix
+  - name: git+git@github.com:ansible-collections/community.general.git
+  - name: git+git@github.com:ansible-collections/community.mysql.git
+  - name: git+git@github.com:ansible-collections/ansible.posix.git

--- a/requirements.yml
+++ b/requirements.yml
@@ -21,5 +21,5 @@ roles:
     version: "2.2.1"
 collections:
   - name: git+https://github.com/ansible-collections/community.general.git
-  - name: git+https://github.com:ansible-collections/community.mysql.git
-  - name: git+https://github.com:ansible-collections/ansible.posix.git
+  - name: git+https://github.com/ansible-collections/community.mysql.git
+  - name: git+https://github.com/ansible-collections/ansible.posix.git

--- a/requirements.yml
+++ b/requirements.yml
@@ -20,6 +20,6 @@ roles:
     src: https://github.com/inmotionhosting/ansible-role-redis
     version: "2.2.1"
 collections:
-  - name: git+git@github.com:ansible-collections/community.general.git
-  - name: git+git@github.com:ansible-collections/community.mysql.git
-  - name: git+git@github.com:ansible-collections/ansible.posix.git
+  - name: git@github.com:ansible-collections/community.general.git
+  - name: git@github.com:ansible-collections/community.mysql.git
+  - name: git@github.com:ansible-collections/ansible.posix.git

--- a/requirements.yml
+++ b/requirements.yml
@@ -20,6 +20,6 @@ roles:
     src: https://github.com/inmotionhosting/ansible-role-redis
     version: "2.2.1"
 collections:
-  - name: git@github.com:ansible-collections/community.general.git
-  - name: git@github.com:ansible-collections/community.mysql.git
-  - name: git@github.com:ansible-collections/ansible.posix.git
+  - name: git+https://github.com/ansible-collections/community.general.git
+  - name: git+https://github.com:ansible-collections/community.mysql.git
+  - name: git+https://github.com:ansible-collections/ansible.posix.git

--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -117,7 +117,7 @@ server {
     }
 {% endif %}
 
-    location ~ {{ nginx_cache_bypass_paths }} {
+    location ~ "{{ nginx_cache_bypass_paths }}" {
         proxy_no_cache 1;
         proxy_cache_bypass 1;
         add_header X-Proxy-Cache $upstream_cache_status;


### PR DESCRIPTION
Anything going to wp-json can probably be omitted from the cache.
Also download collections from GitHub instead of Galaxy until issues with New Galaxy can be resolved.