### PR TITLE
NGX-795: Remove NGINX https redirect

### DIFF
--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -56,12 +56,6 @@ server {
         set $cache_bypass 1;
     }
 
-{% if use_letsencrypt is defined and use_letsencrypt|bool %}
-    if ($scheme != "https") {
-        return 301 https://$host$request_uri;
-    }
-{% endif %}
-
     location / {
         add_header X-Proxy-Cache $upstream_cache_status;
 


### PR DESCRIPTION
The https redirect in our nginx site configuration will cause a redirect loop when used with CloudFlare’s default settings.  It was determined that our config should not be opinionated in this decision to redirect a user.  We should rely on the WordPress site url, or .htaccess (WordPress Plugin code) to do the redirect.