### PR TITLE
NGX-819: Replace ansible_fqdn with ansible_nodename

### DIFF
--- a/templates/etc/httpd/conf.d/site.conf.j2
+++ b/templates/etc/httpd/conf.d/site.conf.j2
@@ -12,16 +12,16 @@
 
 {% if site_domain != ansible_nodename %}
 <VirtualHost *:{{ apache_port_https }}>
-    ServerName {{ ansible_fqdn }}
-    ServerAlias www.{{ ansible_fqdn }}
+    ServerName {{ ansible_nodename }}
+    ServerAlias www.{{ ansible_nodename }}
 
-    ErrorLog /var/log/{{ apache_name }}/ssl-{{ ansible_fqdn }}-error.log
-    CustomLog /var/log/{{ apache_name }}/ssl-{{ ansible_fqdn }}-access.log combined
+    ErrorLog /var/log/{{ apache_name }}/ssl-{{ ansible_nodename }}-error.log
+    CustomLog /var/log/{{ apache_name }}/ssl-{{ ansible_nodename }}-access.log combined
 
     SSLEngine On
-    SSLCertificateFile /etc/letsencrypt/live/{{ ansible_fqdn }}/cert.pem
-    SSLCertificateKeyFile /etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem
-    SSLCertificateChainFile /etc/letsencrypt/live/{{ ansible_fqdn }}/chain.pem
+    SSLCertificateFile /etc/letsencrypt/live/{{ ansible_nodename }}/cert.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/{{ ansible_nodename }}/privkey.pem
+    SSLCertificateChainFile /etc/letsencrypt/live/{{ ansible_nodename }}/chain.pem
 
     SSLProxyEngine on
     SSLProxyCheckPeerCN off

--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -8,10 +8,10 @@ server {
     listen 80;
     listen 443 ssl http2;
 
-    ssl_certificate     /etc/letsencrypt/live/{{ ansible_fqdn }}/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/{{ ansible_fqdn }}/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/{{ ansible_nodename }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ ansible_nodename }}/privkey.pem;
 
-    server_name {{ ansible_fqdn }};
+    server_name {{ ansible_nodename }};
 
     root {{ wp_system_path }};
 


### PR DESCRIPTION
The work done in NGX-808: ansible_fqdn -> ansible_nodename (https://github.com/inmotionhosting/ansible-role-wordpress/pull/55) was incomplete.  This replaces ansible_fqdn with ansible_nodename in a few additional places.