### PR TITLE
NGX-811: Make PHP disable_functions variable configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -166,6 +166,7 @@ children_buffer: 0.75
 php_allow_url_fopen: 'on'
 php_allow_url_include: 'off'
 php_catch_workers_output: 'yes'
+php_disable_functions: 'exec,passthru,shell_exec,system'
 php_request_slowlog_timeout: 0
 
 #

--- a/templates/etc/php-fpm.d/site.conf.j2
+++ b/templates/etc/php-fpm.d/site.conf.j2
@@ -21,7 +21,7 @@ php_admin_flag[log_errors] = on
 
 php_admin_value[doc_root] = "{{ wp_system_path }}"
 
-php_admin_value[disable_functions] = exec,passthru,shell_exec,system
+php_admin_value[disable_functions] = {{ php_disable_functions }}
 php_admin_value[error_log] = {{ php_fpm_site_errorlog }}
 
 php_value[opcache.file_cache] = /var/lib/php/opcache


### PR DESCRIPTION
PHP disable_functions allow the user to customize their PHP configuration for security and other reasons.