### PR TITLE
NGX-817: Handle site_domain when starting with www.

### DIFF
--- a/templates/etc/httpd/conf.d/site.conf.j2
+++ b/templates/etc/httpd/conf.d/site.conf.j2
@@ -90,7 +90,11 @@
 {% if use_letsencrypt|bool %}
 <VirtualHost *:{{ apache_port_https }}>
     ServerName {{ site_domain }}
+{% if site_domain.startswith('www.') %}
+    ServerAlias {{ site_domain[4:] }}
+{% else %}
     ServerAlias www.{{ site_domain }}
+{% endif %}
 
     ErrorLog /var/log/{{ apache_name }}/ssl-{{ site_domain }}-error.log
     CustomLog /var/log/{{ apache_name }}/ssl-{{ site_domain }}-access.log combined

--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -66,7 +66,11 @@ server {
     ssl_certificate_key /etc/letsencrypt/live/{{ site_domain }}/privkey.pem;
 {% endif %}
 
+{% if site_domain.startswith('www.') %}
+    server_name {{ site_domain }} {{ site_domain[4:] }};
+{% else %}
     server_name {{ site_domain }} www.{{ site_domain }};
+{% endif %}
 
     root {{ wp_system_path }};
     


### PR DESCRIPTION
The expected behavior when a server is configured for either www.domain.com or domain.com is that an SSL and the appropriate service configs should be present for both www.domain.com and domain.com.  This commit ensures that is the outcome.