### PR TITLE
NGX-838: Ignore Object Cache flush failures

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -301,6 +301,7 @@
       become: true
       become_user: "{{ system_user }}"
       changed_when: false
+      failed_when: false
       when: "'skipped' not in search_replace"
 
     - name: Ensure WordPress siteurl and homeurl are correct


### PR DESCRIPTION
Ensure task continuity by ignoring non-critical command failures

- Add  to the WordPress cache flush task to prevent non-zero exit codes from failing the playbook execution. This change allows the playbook to continue running even if the cache flush command encounters minor, non-critical errors, ensuring that subsequent tasks are not unjustly impacted by this step's failure status.

This adjustment is made to accommodate scenarios where the wp cache flush command might return a non-zero exit code due to known, benign issues that do not affect the overall success of the operation. It improves playbook resilience and execution consistency across environments with varying cache states.