### PR TITLE
NGX-855: Extend Nginx cache bypass to include Ultrastack paths

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -185,7 +185,7 @@ nginx_ratelimit_paths: ".*login\\.php|xmlrpc\\.php|wp-cron\\.php"
 #
 nginx_cache_bypass_paths: "^(_logged_in_|items_in_cart|jsid|.*/wp-admin|.*/administrator|/admin|\
   /user|/opcache\\.php|.*/phpinfo\\.php|/basket.*|/cart.*|/my-account.*|/checkout.*|/addons.*|\
-  /wp-json.*)"
+  /wp-json.*|/ultrastack.*)"
 nginx_cache_purge_enable: false
 
 #


### PR DESCRIPTION
- Update nginx_cache_bypass_paths regex to include /ultrastack.* pattern. This change ensures that requests to paths starting with /ultrastack are not served from cache, addressing the need for dynamic content delivery and updates related to Ultrastack services like the File Manager and Database Manager.

This modification enhances our Nginx configuration to better support the caching exceptions required for Ultrastack functionalities, ensuring that updates and dynamic content are delivered reliably and without delay.