### PR TITLE
NGX-868: Remove 'listen...http2;' in favor of 'http2 on;'

### DIFF
--- a/templates/etc/nginx/conf.d/default.conf.j2
+++ b/templates/etc/nginx/conf.d/default.conf.j2
@@ -12,8 +12,10 @@ server {
 {% if use_letsencrypt is defined and use_letsencrypt|bool %}
 server {
 
-    listen 443 ssl http2;
+    listen 443 ssl;
     server_name _;
+
+    http2 on;
 
     ssl_certificate     /etc/letsencrypt/live/{{ site_domain }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ site_domain }}/privkey.pem;

--- a/templates/etc/nginx/conf.d/site.conf.j2
+++ b/templates/etc/nginx/conf.d/site.conf.j2
@@ -6,7 +6,9 @@
 {% if site_domain != ansible_nodename %}
 server {
     listen 80;
-    listen 443 ssl http2;
+    listen 443 ssl;
+
+    http2 on;
 
     ssl_certificate     /etc/letsencrypt/live/{{ ansible_nodename }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ ansible_nodename }}/privkey.pem;
@@ -61,7 +63,10 @@ server {
 server {
     listen 80;
 {% if use_letsencrypt is defined and use_letsencrypt|bool %}
-    listen 443 ssl http2;
+    listen 443 ssl;
+
+    http2 on;
+    
     ssl_certificate     /etc/letsencrypt/live/{{ site_domain }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ site_domain }}/privkey.pem;
 {% endif %}


### PR DESCRIPTION
```
Changes with nginx 1.25.1                                        13 Jun 2023

    *) Feature: the "http2" directive, which enables HTTP/2 on a per-server
       basis; the "http2" parameter of the "listen" directive is now
       deprecated.
```