### PR TITLE
Add all-tables to search-replace

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -278,7 +278,7 @@
 
     - name: Replace all site urls in database if changed
       ansible.builtin.command: >-
-        wp search-replace "{{ siteurl.stdout }}" "{{ wp_protocol }}{{ site_domain }}" --skip-plugins --skip-themes
+        wp search-replace "{{ siteurl.stdout }}" "{{ wp_protocol }}{{ site_domain }}" --skip-plugins --skip-themes --all-tables
       args:
         chdir: "{{ wp_system_path }}"
       become: true


### PR DESCRIPTION
In some use-cases, plugins create additional tables that are not included in the default search-replace behavior. Particularly wordpress-seo, which uses a table to store canonical URL's which may persist as the VPS hostname after a playbook.
Resolves NGX-925